### PR TITLE
initial attempt at modified print function writing as xml

### DIFF
--- a/process_stream.lua
+++ b/process_stream.lua
@@ -204,7 +204,7 @@ return function(stream, resources)
   if pcall(function () return pdfscanner.scan(stream, operators, ctx) end) then
  --  io.stderr:write("ok")
   else
-    io.stderr:write("Error parsing marked content stream, returning empty marked content")
+    io.stderr:write("\nError parsing marked content stream, returning empty marked content\n")
   end
   return ctx.marked_content_elements
 end

--- a/process_stream.lua
+++ b/process_stream.lua
@@ -70,7 +70,11 @@ local function print_string(ctx, str, pattern)
   if not pattern or not str then
     str = '\xff\xfd'
   end
-  str = assert(utf16be_to_utf8:match(str))
+  str = utf16be_to_utf8:match(str)
+  if str == nil then
+   io.stderr:write("UTF16 to UTF8 conversion failure\n")
+   str = "??"
+  end
   ctx.text_buffer[#ctx.text_buffer + 1] = str
 end
 

--- a/process_stream.lua
+++ b/process_stream.lua
@@ -29,8 +29,8 @@ local cmap_operators = {
           ctx.mapping[in_prefix .. string.char(in_suffix + i)] = out_prefix .. string.char(out_suffix + i)
         end
       else
-        print(require'inspect'{first, last, target, 'bfrange'})
-        error'TODO'
+        io.stderr:write("\ntarget not string: " .. type(target) .. "\n")
+        io.stderr:write(require'inspect'{first, last, target, 'bfrange'})
       end
     end
   end,

--- a/process_stream.lua
+++ b/process_stream.lua
@@ -201,6 +201,10 @@ return function(stream, resources)
     end
     stream = arr
   end
-  pdfscanner.scan(stream, operators, ctx)
+  if pcall(function () return pdfscanner.scan(stream, operators, ctx) end) then
+ --  io.stderr:write("ok")
+  else
+    io.stderr:write("Error parsing marked content stream, returning empty marked content")
+  end
   return ctx.marked_content_elements
 end

--- a/process_stream.lua
+++ b/process_stream.lua
@@ -204,10 +204,13 @@ return function(stream, resources)
     end
     stream = arr
   end
-  if pcall(function () return pdfscanner.scan(stream, operators, ctx) end) then
+  local s,e
+  s,e= pcall(function () return pdfscanner.scan(stream, operators, ctx) end)
+  if s  then
  --  io.stderr:write("ok")
   else
-    io.stderr:write("\nError parsing marked content stream, returning empty marked content\n")
+    io.stderr:write("\n\n" ..tostring(e))
+    io.stderr:write("\nError parsing marked content stream, returning empty marked content\n\n")
   end
   return ctx.marked_content_elements
 end

--- a/process_stream.lua
+++ b/process_stream.lua
@@ -129,7 +129,7 @@ local operators = {
     end
   end,
   BDC = function(scanner, ctx)
-    local props = assert(scanner:popdictionary() or ctx.properties and ctx.properties[scanner:popname()])
+    local props = assert(scanner:popdictionary() or ctx.properties and ctx.properties[scanner:popname()] or {io.stderr:write("Missing Properties\n")})
     local tag = scanner:popname()
     local stack = ctx.marked_stack
     local top = {

--- a/process_stream.lua
+++ b/process_stream.lua
@@ -29,7 +29,7 @@ local cmap_operators = {
             ctx.mapping[in_prefix .. string.char(in_suffix + i)] = out_prefix .. string.char(out_suffix + i)
           end
         else
-          print(require'inspect'{first, last, target, 'bfrange'})
+          io.stderr:write(require'inspect'{first, last, target, 'bfrange'})
           error'TODO'
         end
       else

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -484,7 +484,7 @@ local function print_tree_xml(tree)
 	        if type(vv) == "table" then
 	          vv = table.concat(vv,' ')
 	        end
-                lines[#lines+1] = ' ' ..attrns .. kk .. '="' .. vv:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
+                lines[#lines+1] = ' ' ..attrns .. kk .. '="' .. tostring(vv):gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
               end
             else
               io.stderr:write("Unexpected attributes object\n")

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -185,7 +185,7 @@ local function convert(ctx, elem, id, page)
     expanded = get_string(elem, 'E'),
     actual_text = get_string(elem, 'ActualText'),
     associated_files = elem.AF,
-    id = get_string(pdfe.getfromdictionary(elem, 'ID')),
+    id = get_string(elem, 'ID'),
     kids = convert_kids(ctx, elem),
   }
   ctx.id_map[id] = obj

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -557,6 +557,7 @@ local helpstr =[[
 
 Usage: %s options <filename>.pdf
 Options
+  --help           show this help
   --tree (default) show as tree
   --xml            show as XML
   --table          show Lua table structure

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -487,8 +487,10 @@ local function print_tree_xml(tree)
         end
         if obj.attributes then
 	  for k,v in pairs(obj.attributes) do
-           local attrns= k:gsub('.*/','')
-	   if attrns=="MathML" then attrns="" end
+           local attrns=""
+	   if k~=subtype.namespace then
+	     attrns = k:gsub('.*/','')
+	   end
             if type(v) == "table" then
 	      if attrns ~= "" then
                 lines[#lines +1] = ' xmlns:' .. attrns .. '="' .. k .. '"'

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -451,7 +451,8 @@ local function print_tree_xml(tree)
       else
         local subtype = obj.subtype
         local mapped = subtype.mapped
-        mapped = mapped and ' / ' .. format_subtype(mapped) or ''
+        mapped = mapped and mapped.subtype or ''
+--        mapped = mapped and ' / ' .. format_subtype(mapped) or ''
         print(string.format('%s%s', indent, format_subtype_xml(subtype)))
         local lines = {}
         if obj.title then
@@ -492,12 +493,12 @@ local function print_tree_xml(tree)
             end
           end
         end
+	if mapped ~= "" then
+          lines[#lines+1] = ' rolemaps-to="' .. mapped .. '"'
+	end
         -- attributes = convert_attributes(elem.A),
         -- attribute_classes = convert_attribute_classes(elem.C),
 	lines[#lines+1] = ">"
-	if mapped ~= "" then
-          lines[#lines+1] = '<?Map ' .. mapped .. ' ?>'
-	end
         if referenced[obj] then
           lines[#lines + 1] = '<?ReferencedAs object ' .. referenced[obj] .. ' ?>'
         end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -466,22 +466,22 @@ local function print_tree_xml(tree)
 	end
         local lines = {}
         if obj.id then
-          lines[#lines + 1] = ' id="' .. obj.id:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
+          lines[#lines + 1] = ' id="' .. obj.id:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]') .. '"'
         end
         if obj.title then
-          lines[#lines + 1] = ' title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
+          lines[#lines + 1] = ' title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]') .. '"'
         end
         if obj.lang then
           lines[#lines + 1] = ' lang="' .. obj.lang .. '"'
         end
         if obj.expanded then
-          lines[#lines + 1] = ' expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;')  .. '"'
+          lines[#lines + 1] = ' expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]')  .. '"'
         end
         if obj.alt then
-          lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;')  .. '"'
+          lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]')  .. '"'
         end
         if obj.actual_text then
-          lines[#lines + 1] = ' actualtext="' .. obj.actual_text:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
+          lines[#lines + 1] = ' actualtext="' .. obj.actual_text:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]') .. '"'
         end
         if obj.associated_files then
           lines[#lines + 1] = ' af="yes"'
@@ -501,7 +501,7 @@ local function print_tree_xml(tree)
 	        if type(vv) == "table" then
 	          vv = table.concat(vv,' ')
 	        end
-                lines[#lines+1] = ' ' ..attrns .. kk .. '="' .. tostring(vv):gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
+                lines[#lines+1] = ' ' ..attrns .. kk .. '="' .. tostring(vv):gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]') .. '"'
               end
             else
               io.stderr:write("Unexpected attributes object\n")

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -567,24 +567,20 @@ Options
 
 local argi = 1
 while argi < #arg and arg[argi]:match("^%-%-") do
-  if arg[argi] == "--xml" then
+  if arg[argi] == "--tree" then
+    out_format="tree"
+  elseif arg[argi] == "--xml" then
     out_format="xml"
+  elseif arg[argi] == "--table" then
+    out_format="table"
+  elseif arg[argi] == "--map" then
+    follow_rolemap=true
+  elseif arg[argi] == "--help" then
+    io.stderr:write(string.format(helpstr, arg[0]))
+    return
   else
-    if arg[argi] == "--table" then
-      out_format="table"
-    else
-      if arg[argi] == "--map" then
-        follow_rolemap=true
-      else
-        if arg[argi] == "--help" then
-          io.stderr:write(string.format(helpstr, arg[0]))
-          return
-        else
-          io.stderr:write(string.format('Unknown option: %s\n', arg[argi]))
-          return
-        end
-      end
-    end
+    io.stderr:write(string.format('Unknown option: %s\n', arg[argi]))
+    return
   end
   argi=argi+1
 end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -470,7 +470,7 @@ local function print_tree_xml(tree)
           lines[#lines + 1] = 'lang="' .. obj.lang .. '"'
         end
         if obj.expanded then
-          lines[#lines + 1] = 'expansion="' .. obj.expanded  .. '"'
+          lines[#lines + 1] = 'expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'
         end
         if obj.alt then
           lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -6,6 +6,7 @@ end
 
 local out_format = "tree"
 local follow_rolemap = false
+local hide_w3c = false
 
 local pdfe = pdfe or require'pdfe'
 local process_stream = require'process_stream'
@@ -331,7 +332,8 @@ end
 
 local function format_subtype_xml(subtype)
   if subtype.namespace then
-    return string.format('<%s xmlns="%s"', subtype.subtype, subtype.namespace)
+    return string.format('<%s xmlns="%s"', subtype.subtype,
+                  (hide_w3c and subtype.namespace:gsub('http://www.w3.org', 'http://-www.w3.org')) or subtype.namespace)
   else
     return "<" .. subtype.subtype
   end
@@ -578,6 +580,7 @@ Options
   --xml            show as XML
   --table          show Lua table structure
   --map            Follow role mapping (xml printer)
+  --w3c-           Add - to w3c namespaces to force browser tree display
 
 ]]
 
@@ -591,6 +594,8 @@ while argi < #arg and arg[argi]:match("^%-%-") do
     out_format="table"
   elseif arg[argi] == "--map" then
     follow_rolemap=true
+  elseif arg[argi] == "--w3c-" then
+    hide_w3c=true
   elseif arg[argi] == "--help" then
     io.stderr:write(string.format(helpstr, arg[0]))
     return

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -447,7 +447,7 @@ local function print_tree_xml(tree)
   local function recurse(objs, indent)
     for i, obj in ipairs(objs) do
       if obj.type == 'MCR' then
-        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, (obj.content and obj.content:gsub('&','&amp;'):gsub('<','&lt;') or "[empty]")))
+        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, (obj.content and obj.content:gsub('&','&amp;'):gsub('<','&lt;'):gsub('\0','[NULL]') or "[empty]")))
       elseif obj.type == 'OBJR' then
         local t = obj.Obj.Type
         t = t and string.format(' type="%s"', t) or ''

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -446,7 +446,7 @@ local function print_tree_xml(tree)
   local function recurse(objs, indent)
     for i, obj in ipairs(objs) do
       if obj.type == 'MCR' then
-        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, obj.content:gsub('&','&amp;'):gsub('<','&lt;')))
+        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, (obj.content and obj.content:gsub('&','&amp;'):gsub('<','&lt;') or "[empty]")))
       elseif obj.type == 'OBJR' then
         local t = obj.Obj.Type
         t = t and string.format(' type="%s"', t) or ''

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -449,7 +449,7 @@ local function print_tree_xml(tree)
         print(string.format('%s%s%s', indent, format_subtype_xml(subtype), mapped))
         local lines = {}
         if obj.title then
-          lines[#lines + 1] = 'title="' .. obj.title .. '"'
+          lines[#lines + 1] = 'title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
         end
         if obj.lang then
           lines[#lines + 1] = 'lang="' .. obj.lang .. '"'
@@ -458,10 +458,10 @@ local function print_tree_xml(tree)
           lines[#lines + 1] = 'expansion="' .. obj.expanded  .. '"'
         end
         if obj.alt then
-          lines[#lines + 1] = ' alt="' .. obj.alt  .. '"'
+          lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'
         end
         if obj.actual_text then
-          lines[#lines + 1] = ' actualtext="' .. obj.actual_text .. '"'
+          lines[#lines + 1] = ' actualtext="' .. obj.actual_text:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
         end
         if obj.associated_files then
           lines[#lines + 1] = ' af="yes"'

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -58,7 +58,8 @@ local function convert_objr(ctx, obj, page)
 end
 
 local default_namespace = 'http://iso.org/pdf/ssn'
-local owner_prefix = 'http://typesetting.eu/pdf_attribute_owner/'
+-- this prefix to be confirmed, another possibility would be data:,
+local owner_prefix = 'http://iso.org/pdf/ssn/'
 
 local dehex = lpeg.Cs(
     (lpeg.R('09', 'af', 'AF') * lpeg.R('09', 'af', 'AF') / function(s) return string.char(tonumber(s, 16)) end)^0

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -481,8 +481,8 @@ local function print_tree_xml(tree)
             for j=1, #attrs do
               attrs[j] = attrs[j] .. '="' .. (require'inspect'(obj.attributes[owners[i]][attrs[j]])):gsub('"','') .. '"'
             end
-            table.insert(attrs, 1, (owners[i]:sub(1, #owner_prefix) == owner_prefix and  owners[i]:sub(#owner_prefix+1) or  owners[i]) .. '-')
-            owners[i] = table.concat(attrs, ':+', 1, #attrs-1) .. '' .. attrs[#attrs]
+            table.insert(attrs, 1, (owners[i]:sub(1, #owner_prefix) == owner_prefix and  owners[i]:sub(#owner_prefix+1) or  owners[i]):gsub('.*/','') .. '-')
+            owners[i] = (table.concat(attrs, '<>', 1, #attrs-1) .. '<>' .. attrs[#attrs]):gsub('-<>','-'):gsub('<>',' ')
           end
           lines[#lines + 1] = owners[#owners]
         end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -137,6 +137,7 @@ local function convert_attributes(ctx, attrs, classes)
     end
   end
   local function apply_attrs(attrs)
+    if t ~= nil then
     local t = pdfe.type(attrs)
     if t == 'pdfe.dictionary' then
       apply_attr(attrs)
@@ -149,6 +150,7 @@ local function convert_attributes(ctx, attrs, classes)
         end
       end
     end
+  end
   end
   if classes then
     if type(classes) == 'string' then

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -445,12 +445,12 @@ local function print_tree_xml(tree)
   local function recurse(objs, indent)
     for i, obj in ipairs(objs) do
       if obj.type == 'MCR' then
-        print(string.format('%s<?MarkedContent on page %i ?>%s', indent, obj.page, obj.content:gsub('&','&amp;'):gsub('<','&lt;')))
+        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, obj.content:gsub('&','&amp;'):gsub('<','&lt;')))
       elseif obj.type == 'OBJR' then
         local t = obj.Obj.Type
-        t = t and string.format(' of type %s', t) or ''
+        t = t and string.format(' type="%s"', t) or ''
         local page = obj.page
-        page = page and string.format(' on page %i', page) or '' -- TODO: Should eventually become always true
+        page = page and string.format(' page="%i"', page) or '' -- TODO: Should eventually become always true
         print(string.format('%s<?ReferencedObject%s%s ?>', indent, t, page))
       else
         local subtype = obj.subtype

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -64,7 +64,12 @@ local owner_prefix = 'http://iso.org/pdf/ssn/'
 local function get_string(container, index)
   local text = pdfe.getstring(container, index, true)
   if text then
-    return assert(text_string_to_utf8:match(text))
+    local u = text_string_to_utf8:match(text)
+    if u == nil then
+    io.stderr:write("UTF8 conversion failure\n")
+    u="??"
+    end
+    return u
   else
     return
   end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -456,7 +456,7 @@ local function print_tree_xml(tree)
 	local mapped = subtype.mapped
 --        mapped = mapped and mapped.subtype or ''
 --        mapped = mapped and ' / ' .. format_subtype(mapped) or ''
-        if follow_rolemap then
+        if follow_rolemap and mapped then
           print(string.format('%s%s', indent, format_subtype_xml(mapped)))
 	else
           print(string.format('%s%s', indent, format_subtype_xml(subtype)))
@@ -530,13 +530,21 @@ local function print_tree_xml(tree)
             print(indent .. '  ' .. l:gsub('\n', '\n' .. indent .. '  '))
           end
           recurse(obj.kids, indent .. ' ')
+        if follow_rolemap and mapped then
+	  print(indent .. "</" .. mapped.subtype ..">")
+	else
 	  print(indent .. "</" .. subtype.subtype ..">")
+	end
         elseif #lines > 0 then
           for i=1, #lines-1 do
             print(indent .. '  ' .. lines[i]:gsub('\n', '\n' .. indent .. '  '))
           end
           print(indent .. '  ' .. lines[#lines]:gsub('\n', '\n' .. indent .. '   '))
-	  print(indent .. "</" .. subtype.subtype ..">")
+          if follow_rolemap and mapped then
+            print(indent .. "</" .. mapped.subtype ..">")
+	  else
+            print(indent .. "</" .. subtype.subtype ..">")
+	  end
         end
       end
     end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -189,6 +189,7 @@ local function convert(ctx, elem, id, page)
     expanded = get_string(pdfe.getfromdictionary(elem, 'E')),
     actual_text = get_string(pdfe.getfromdictionary(elem, 'ActualText')),
     associated_files = elem.AF,
+    id = get_string(pdfe.getfromdictionary(elem, 'ID')),
     kids = convert_kids(ctx, elem),
   }
   ctx.id_map[id] = obj
@@ -463,14 +464,17 @@ local function print_tree_xml(tree)
           print(string.format('%s%s', indent, format_subtype_xml(subtype)))
 	end
         local lines = {}
+        if obj.id then
+          lines[#lines + 1] = ' id="' .. obj.id:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
+        end
         if obj.title then
-          lines[#lines + 1] = 'title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
+          lines[#lines + 1] = ' title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
         end
         if obj.lang then
-          lines[#lines + 1] = 'lang="' .. obj.lang .. '"'
+          lines[#lines + 1] = ' lang="' .. obj.lang .. '"'
         end
         if obj.expanded then
-          lines[#lines + 1] = 'expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'
+          lines[#lines + 1] = ' expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'
         end
         if obj.alt then
           lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -484,10 +484,10 @@ local function print_tree_xml(tree)
             end
             table.sort(attrs)
             for j=1, #attrs do
-              attrs[j] = attrs[j] .. '="' .. (require'inspect'(obj.attributes[owners[i]][attrs[j]])):gsub('"','') .. '"'
+              attrs[j] = attrs[j] .. '="' .. (require'inspect'(obj.attributes[owners[i]][attrs[j]])):gsub('"',''):gsub("MathML-","") .. '"'
             end
             table.insert(attrs, 1, (owners[i]:sub(1, #owner_prefix) == owner_prefix and  owners[i]:sub(#owner_prefix+1) or  owners[i]):gsub('.*/','') .. '-')
-            owners[i] = (table.concat(attrs, '<>', 1, #attrs-1) .. '<>' .. attrs[#attrs]):gsub('-<>','-'):gsub('<>',' ')
+            owners[i] = (table.concat(attrs, '<>', 1, #attrs-1) .. '<>' .. attrs[#attrs]):gsub('-<>','-'):gsub('<>',' '):gsub("MathML-","")
           end
           lines[#lines + 1] = owners[#owners]
         end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -525,14 +525,14 @@ local function print_tree_xml(tree)
         -- attribute_classes = convert_attribute_classes(elem.C),
 	lines[#lines+1] = ">"
         if referenced[obj] then
-          lines[#lines + 1] = '<?ReferencedAs object ' .. referenced[obj] .. ' ?>'
+          lines[#lines + 1] = '<?ReferencedAs object="' .. referenced[obj] .. '" ?>'
         end
         if obj.ref then
           local refs = {}
           for i, r in ipairs(obj.ref) do
             refs[i] = referenced[r]
           end
-          lines[#lines + 1] = '<?Referencesobject' .. (refs[2] and 's' or '') .. ' ' .. table.concat(refs, ', ') ..' ?>'
+          lines[#lines + 1] = '<?References objects="' .. table.concat(refs, ' ') ..'" ?>'
         end
         if obj.kids then
           for _, l in ipairs(lines) do

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -453,10 +453,14 @@ local function print_tree_xml(tree)
         print(string.format('%s<?ReferencedObject%s%s ?>', indent, t, page))
       else
         local subtype = obj.subtype
-        local mapped = subtype.mapped
-        mapped = mapped and mapped.subtype or ''
+	local mapped = subtype.mapped
+--        mapped = mapped and mapped.subtype or ''
 --        mapped = mapped and ' / ' .. format_subtype(mapped) or ''
-        print(string.format('%s%s', indent, format_subtype_xml(subtype)))
+        if follow_rolemap then
+          print(string.format('%s%s', indent, format_subtype_xml(mapped)))
+	else
+          print(string.format('%s%s', indent, format_subtype_xml(subtype)))
+	end
         local lines = {}
         if obj.title then
           lines[#lines + 1] = 'title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
@@ -496,8 +500,17 @@ local function print_tree_xml(tree)
             end
           end
         end
-	if mapped ~= "" then
-          lines[#lines+1] = ' rolemaps-to="' .. mapped .. '"'
+	if mapped and mapped.subtype then
+          if follow_rolemap then
+	    if subtype.namespace then
+              lines[#lines+1] = ' xmlns:orig-ns="' .. subtype.namespace .. '"'
+              lines[#lines+1] = ' rolemapped-from="orig-ns:' .. subtype.subtype .. '"'
+	    else
+              lines[#lines+1] = ' rolemapped-from="' .. subtype.subtype .. '"'
+	    end
+	  else
+            lines[#lines+1] = ' rolemaps-to="' .. mapped.subtype .. '"'
+	  end
 	end
         -- attributes = convert_attributes(elem.A),
         -- attribute_classes = convert_attribute_classes(elem.C),

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -484,10 +484,10 @@ local function print_tree_xml(tree)
             end
             table.sort(attrs)
             for j=1, #attrs do
-              attrs[j] = attrs[j] .. '="' .. (require'inspect'(obj.attributes[owners[i]][attrs[j]])):gsub('"',''):gsub("MathML-","") .. '"'
+              attrs[j] = attrs[j] .. '="' .. (require'inspect'(obj.attributes[owners[i]][attrs[j]])):gsub('"','') .. '"'
             end
             table.insert(attrs, 1, (owners[i]:sub(1, #owner_prefix) == owner_prefix and  owners[i]:sub(#owner_prefix+1) or  owners[i]):gsub('.*/','') .. '-')
-            owners[i] = (table.concat(attrs, '<>', 1, #attrs-1) .. '<>' .. attrs[#attrs]):gsub('-<>','-'):gsub('<>',' '):gsub("MathML-","")
+            owners[i] = (table.concat(attrs, '<>', 1, #attrs-1) .. '<>' .. attrs[#attrs]):gsub('-<>','-'):gsub('<>',' '):gsub("MathML[-]","")
           end
           lines[#lines + 1] = owners[#owners]
         end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -447,7 +447,7 @@ local function print_tree_xml(tree)
   local function recurse(objs, indent)
     for i, obj in ipairs(objs) do
       if obj.type == 'MCR' then
-        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, (obj.content and obj.content:gsub('&','&amp;'):gsub('<','&lt;'):gsub('\0','[NULL]') or "[empty]")))
+        print(string.format('%s<?MarkedContent page="%i" ?>%s', indent, obj.page, (obj.content and obj.content:gsub('&','&amp;'):gsub('<','&lt;'):gsub('\0','[NULL]'):gsub('[\1-\8\11\12\14-\31]','[CTRL]') or "[empty]")))
       elseif obj.type == 'OBJR' then
         local t = obj.Obj.Type
         t = t and string.format(' type="%s"', t) or ''

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -451,7 +451,7 @@ local function print_tree_xml(tree)
         local subtype = obj.subtype
         local mapped = subtype.mapped
         mapped = mapped and ' / ' .. format_subtype(mapped) or ''
-        print(string.format('%s%s%s', indent, format_subtype_xml(subtype), mapped))
+        print(string.format('%s%s', indent, format_subtype_xml(subtype)))
         local lines = {}
         if obj.title then
           lines[#lines + 1] = 'title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
@@ -494,6 +494,9 @@ local function print_tree_xml(tree)
         -- attributes = convert_attributes(elem.A),
         -- attribute_classes = convert_attribute_classes(elem.C),
 	lines[#lines+1] = ">"
+	if mapped ~= "" then
+          lines[#lines+1] = '<?Map ' .. mapped .. ' ?>'
+	end
         if referenced[obj] then
           lines[#lines + 1] = '<?ReferencedAs object ' .. referenced[obj] .. ' ?>'
         end

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -72,7 +72,12 @@ local function get_string(t, v, x)
   if x then
     v = assert(dehex:match(v))
   end
-  return assert(text_string_to_utf8:match(v))
+  local u = text_string_to_utf8:match(v)
+  if u == nil then
+    io.stderr:write("\nUTF-8 failure on: " .. v .. "\n")
+    u = "??"
+  end
+  return u
 end
 
 local function pdf2lua(t, v, x)
@@ -467,22 +472,22 @@ local function print_tree_xml(tree)
 	end
         local lines = {}
         if obj.id then
-          lines[#lines + 1] = ' id="' .. obj.id:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
+          lines[#lines + 1] = ' id="' .. obj.id:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
         end
         if obj.title then
-          lines[#lines + 1] = ' title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
+          lines[#lines + 1] = ' title="' .. obj.title:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
         end
         if obj.lang then
           lines[#lines + 1] = ' lang="' .. obj.lang .. '"'
         end
         if obj.expanded then
-          lines[#lines + 1] = ' expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'
+          lines[#lines + 1] = ' expansion="' .. obj.expanded:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;')  .. '"'
         end
         if obj.alt then
-          lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;')  .. '"'
+          lines[#lines + 1] = ' alt="' .. obj.alt:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;')  .. '"'
         end
         if obj.actual_text then
-          lines[#lines + 1] = ' actualtext="' .. obj.actual_text:gsub('&','&amp;'):gsub('<','&lt;') .. '"'
+          lines[#lines + 1] = ' actualtext="' .. obj.actual_text:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
         end
         if obj.associated_files then
           lines[#lines + 1] = ' af="yes"'
@@ -558,7 +563,15 @@ local function print_tree_xml(tree)
       end
     end
   end
-  return recurse(tree, '', '', '', '')
+  if #tree ==1 then
+    return recurse(tree, '', '', '', '')
+  else
+    io.stderr:write("\nMultiple document elements\n")
+    print ("<Document>")
+    recurse(tree, '  ', '', '', '')
+    print ("</Document>")
+    return
+  end
 end
 
 

--- a/show_pdf_tags.lua
+++ b/show_pdf_tags.lua
@@ -472,24 +472,24 @@ local function print_tree_xml(tree)
           lines[#lines + 1] = ' af="yes"'
         end
         if obj.attributes then
-          local owners = {}
-          for k in next, obj.attributes do
-            owners[#owners + 1] = k
-          end
-          table.sort(owners)
-          for i=1, #owners do
-            local attrs = {}
-            for k in next, obj.attributes[owners[i]] do
-              attrs[#attrs + 1] = k
+	  for k,v in pairs(obj.attributes) do
+           local attrns= k:gsub('.*/','')
+	   if attrns=="MathML" then attrns="" end
+            if type(v) == "table" then
+	      if attrns ~= "" then
+                lines[#lines +1] = ' xmlns:' .. attrns .. '="' .. k .. '"'
+		attrns = attrns ..':'
+              end
+              for kk,vv in pairs(v) do
+	        if type(vv) == "table" then
+	          vv = table.concat(vv,' ')
+	        end
+                lines[#lines+1] = ' ' ..attrns .. kk .. '="' .. vv:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;') .. '"'
+              end
+            else
+              io.stderr:write("Unexpected attributes object\n")
             end
-            table.sort(attrs)
-            for j=1, #attrs do
-              attrs[j] = attrs[j] .. '="' .. (require'inspect'(obj.attributes[owners[i]][attrs[j]])):gsub('"','') .. '"'
-            end
-            table.insert(attrs, 1, (owners[i]:sub(1, #owner_prefix) == owner_prefix and  owners[i]:sub(#owner_prefix+1) or  owners[i]):gsub('.*/','') .. '-')
-            owners[i] = (table.concat(attrs, '<>', 1, #attrs-1) .. '<>' .. attrs[#attrs]):gsub('-<>','-'):gsub('<>',' '):gsub("MathML[-]","")
           end
-          lines[#lines + 1] = owners[#owners]
         end
         -- attributes = convert_attributes(elem.A),
         -- attribute_classes = convert_attribute_classes(elem.C),


### PR DESCRIPTION
@zauguin as discussed elsewhere a version of the print function producing xml (it is well formed on tagpdf.pdf at least)
You probably don't want to take the PR as-is but I'm posting it as  a PR anyway to link to the code.

<strike>Note there is one unrelated change the original version access a null field handling the mapping, the code here "guards" that but I didn't fully follow the construct and I suspect I have disabled the mapping being shown. Otherwise this just adds a new `print_tree_xml` function that's more or less a copy of the `print_tree` function but using angle backet syntax.</strike>

The PR adds an xml output format

it also adds a basic option handler with options

```
Usage: %s options <filename>.pdf
Options
  --help           show this help
  --tree (default) show as tree
  --xml            show as XML
  --table          show Lua table structure
  --map            Follow role mapping (xml printer)
```

the map option changes whether the tree is shown as

```
    <text xmlns="https://www.latex-project.org/ns/dflt/2022"
       xmlns:Layout="http://typesetting.eu/pdf_attribute_owner/Layout"
       Layout:TextAlign="Justify"
       rolemaps-to="P"
      >
```

or

```
    <P xmlns="http://iso.org/pdf2/ssn"
       xmlns:Layout="http://typesetting.eu/pdf_attribute_owner/Layout"
       Layout:TextAlign="Justify"
       xmlns:orig-ns="https://www.latex-project.org/ns/dflt/2022"
       rolemapped-from="orig-ns:text"
      >
```

The first form shows the document-intended structure but needs a custom schema for validation, the second form should only use standard elements so allow any document to be validated.

