### PR TITLE
phoneme, phoneticAlphabet and (in schema) revision

### DIFF
--- a/RelaxNG/document-pdf-ua1.rnc
+++ b/RelaxNG/document-pdf-ua1.rnc
@@ -51,12 +51,15 @@ otherns-attributes =
 
 # Properties are modelled as attributes in no namespace
 structure-properties =
-  attribute lang {text}?,         # Lang
-  attribute expanded {text}?,     # E
-  attribute actualtext {text}?,   # ActualText
-  attribute alt {text}?,          # Alt
-  attribute title {text}?,        # T
-  attribute id {text}?            # ID
+  attribute lang {text}?,              # Lang
+  attribute expanded {text}?,          # E
+  attribute actualtext {text}?,        # ActualText
+  attribute alt {text}?,               # Alt
+  attribute title {text}?,             # T
+  attribute id {text}?,                # ID
+  attribute phoneme {text}?,           # Phoneme
+  attribute phonetic-alphabet {text}?, # PhoneticAlphabet
+  attribute revision {text}?           # R
   
 layout-attributes =
   # Only validate Layout attributes with Owner Layout

--- a/RelaxNG/document-pdf-ua1.rng
+++ b/RelaxNG/document-pdf-ua1.rng
@@ -129,8 +129,20 @@
       <!-- T -->
       <attribute name="id"/>
     </optional>
+    <optional>
+      <!-- ID -->
+      <attribute name="phoneme"/>
+    </optional>
+    <optional>
+      <!-- Phoneme -->
+      <attribute name="phonetic-alphabet"/>
+    </optional>
+    <optional>
+      <!-- PhoneticAlphabet -->
+      <attribute name="revision"/>
+    </optional>
   </define>
-  <!-- ID -->
+  <!-- R -->
   <define name="layout-attributes">
     <optional>
       <!--

--- a/RelaxNG/document-pdf-ua2.rnc
+++ b/RelaxNG/document-pdf-ua2.rnc
@@ -63,12 +63,15 @@ otherns-attributes =
 
 # Properties are modelled as attributes in no namespace
 structure-properties =
-  attribute lang {text}?,         # Lang
-  attribute expanded {text}?,     # E
-  attribute actualtext {text}?,   # ActualText
-  attribute alt {text}?,          # Alt
-  attribute title {text}?,        # T
-  attribute id {text}?            # ID
+  attribute lang {text}?,              # Lang
+  attribute expanded {text}?,          # E
+  attribute actualtext {text}?,        # ActualText
+  attribute alt {text}?,               # Alt
+  attribute title {text}?,             # T
+  attribute id {text}?,                # ID
+  attribute phoneme {text}?,           # Phoneme
+  attribute phonetic-alphabet {text}?, # PhoneticAlphabet
+  attribute revision {text}?           # R
   
 layout-attributes =
   # Only validate Layout attributes with Owner Layout

--- a/RelaxNG/document-pdf-ua2.rng
+++ b/RelaxNG/document-pdf-ua2.rng
@@ -120,8 +120,20 @@
       <!-- T -->
       <attribute name="id"/>
     </optional>
+    <optional>
+      <!-- ID -->
+      <attribute name="phoneme"/>
+    </optional>
+    <optional>
+      <!-- Phoneme -->
+      <attribute name="phonetic-alphabet"/>
+    </optional>
+    <optional>
+      <!-- PhoneticAlphabet -->
+      <attribute name="revision"/>
+    </optional>
   </define>
-  <!-- ID -->
+  <!-- R -->
   <define name="layout-attributes">
     <optional>
       <!--

--- a/show_pdf_tags/show_pdf_tags.lua
+++ b/show_pdf_tags/show_pdf_tags.lua
@@ -196,6 +196,8 @@ local function convert(ctx, elem, id, page)
     actual_text = get_string(elem, 'ActualText'),
     associated_files = elem.AF,
     id = get_string(elem, 'ID'),
+    phoneme = get_string(elem, 'Phoneme'),
+    phonetic_alphabet = get_string(elem, 'PhoneticAlphabet'),
     kids = convert_kids(ctx, elem),
   }
   ctx.id_map[id] = obj
@@ -398,6 +400,12 @@ local function print_tree(tree)
         if obj.actual_text then
           lines[#lines + 1] = 'Actual text: ' .. obj.actual_text
         end
+        if obj.phoneme then
+          lines[#lines + 1] = 'Phoneme: ' .. obj.phoneme
+        end
+        if obj.phonetic_alphabet then
+          lines[#lines + 1] = 'PhoneticAlphabet: ' .. obj.phonetic_alphabet
+        end
         if obj.associated_files then
           local af_output = ''
           local total_count = #af_output
@@ -505,6 +513,12 @@ local function print_tree_xml(tree)
         end
         if obj.actual_text then
           lines[#lines + 1] = ' actualtext="' .. obj.actual_text:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]'):gsub('[\1-\8\11\12\14-\31]','[CTRL]') .. '"'
+        end
+        if obj.phoneme then
+          lines[#lines + 1] = ' phoneme="' .. obj.phoneme:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]'):gsub('[\1-\8\11\12\14-\31]','[CTRL]') .. '"'
+        end
+        if obj.phonetic_alphabet then
+          lines[#lines + 1] = ' phonetic-alphabet="' .. obj.phonetic_alphabet:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]'):gsub('[\1-\8\11\12\14-\31]','[CTRL]') .. '"'
         end
         if obj.associated_files then
 	  local f = {}


### PR DESCRIPTION
This adds display of Phoneme and PhoneticAlphabet properties and allows them in the XML schema (which also adds revision)

The PR is against trunk so independent of the PR adding WinANSI

LaTeX can add Phoneme keys using the `phoneme` branch of tagpdf.