### PR TITLE
allow output for documents with no markinfo entry

### DIFF
--- a/RelaxNG/latex-document-switch.rnc
+++ b/RelaxNG/latex-document-switch.rnc
@@ -2,4 +2,5 @@ ua2 = external "latex-bible.rnc"
 ua1 = external "latex-bible17.rnc"
 ua2play = external "latex-play.rnc"
 ua1play = external "latex-play17.rnc"
-start = ua2 | ua1 | ua2play | ua1play
+xbeamer = external "latex-xbeamer.rnc"
+start = ua2 | ua1 | ua2play | ua1play | xbeamer

--- a/RelaxNG/latex-document-switch.rng
+++ b/RelaxNG/latex-document-switch.rng
@@ -12,12 +12,16 @@
   <define name="ua1play">
     <externalRef href="latex-play17.rng"/>
   </define>
+  <define name="xbeamer">
+    <externalRef href="latex-xbeamer.rng"/>
+  </define>
   <start>
     <choice>
       <ref name="ua2"/>
       <ref name="ua1"/>
       <ref name="ua2play"/>
       <ref name="ua1play"/>
+      <ref name="xbeamer"/>
     </choice>
   </start>
 </grammar>

--- a/RelaxNG/latex-xbeamer.rnc
+++ b/RelaxNG/latex-xbeamer.rnc
@@ -1,0 +1,30 @@
+
+namespace latexSE = "https://www.latex-project.org/ns/dflt"
+namespace latexSExbeamer = "https://www.latex-project.org/ns/local/xbeamer"
+
+## PDF/UA-2
+
+include "latex-document.rnc"
+
+# LaTeX Xbeamer Markup Namepace
+
+  
+Sect |= element latexSExbeamer:frame {
+  pdf2-attributes,
+  attribute rolemaps-to {"Sect"},
+  frametitle?,slide*}
+
+
+
+frametitle = element latexSExbeamer:frametitle {
+  pdf2-attributes,
+  attribute rolemaps-to {"H1"},
+  (text|Span)*
+}
+
+slide = element latexSExbeamer:slide {
+  pdf2-attributes,
+  attribute rolemaps-to {"Div"},
+  (text|text-unit)*
+}
+

--- a/show_pdf_tags/show_pdf_tags.lua
+++ b/show_pdf_tags/show_pdf_tags.lua
@@ -263,7 +263,7 @@ local function open(filename)
   local tagged = markinfo and markinfo.Marked
 
   if not tagged then
-    return nil, 'Document is not tagged'
+   io.stderr:write("Document catalog has no markinfo.Marked entry. It might not be tagged.\n")
   end
 
   local pagenos = {}


### PR DESCRIPTION
Allow a document with no markinfo/marked entry (which aligns with ngpdf and verapdf) It does give a warning on stderr.

Made as a PR against the winansi branch to simplify use at 
https://texlive.net/showtags
which currently uses that branch.