### PR TITLE
xmp option to add XMP data to xml output

### DIFF
--- a/RelaxNG/document-pdf-ua1.rnc
+++ b/RelaxNG/document-pdf-ua1.rnc
@@ -11,6 +11,12 @@ namespace Table = "http://iso.org/pdf/ssn/Table"
 namespace List = "http://iso.org/pdf/ssn/List"
 namespace Artifact = "http://iso.org/pdf/ssn/Artifact"
 
+# XMP
+namespace x = "adobe:ns:meta/"
+namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+namespace dc = "http://purl.org/dc/elements/1.1/"
+namespace pdfuaid = "http://www.aiim.org/pdfua/ns/id/"
+
 # XHTML Namespace, not currently used
 namespace h = "http://www.w3.org/1999/xhtml"
 
@@ -63,11 +69,23 @@ formula-requirements = (
   attribute alt {text}
 )
 
+## PDF/UA-1
+pdfuaid_part = element pdfuaid:part {"1"}
+
 ## share with pdf1.7 version from here to end
 
-XMP = element NoNS:XMP {anyelem*}
+# XMP data
+anyelem = element * {(attribute * {text}* | text | anyelem) *}
 
-anyelem = element * {(attribute * {text} | text | anyelem) *}
+XMP = element NoNS:XMP {x_xmpmeta & anyelem*}
+
+x_xmpmeta = element x:xmpmeta {attribute * {text}*,(rdf_RDF &  anyelem*)}
+
+rdf_RDF= element rdf:RDF {attribute * {text}*, (rdf_Description & anyelem*)}
+
+rdf_Description= element rdf:Description {attribute * {text}*, (pdfuaid_part & anyelem*)}
+
+# end of XMP
 
 textorHTML &= (Link|Reference|Strong|Code|Em|Lbl|Span|mathse|Quote|RB|Annot|Figure|Form)*
 

--- a/RelaxNG/document-pdf-ua1.rnc
+++ b/RelaxNG/document-pdf-ua1.rnc
@@ -40,7 +40,8 @@ pdf1rolemap-Note = attribute rolemaps-to {"Note"}
 # UA-1 does not force a single document element.
 start = PDF
 
-PDF = element NoNS:PDF {StructTreeRoot}
+PDF = element NoNS:PDF {StructTreeRoot,XMP?}
+
 StructTreeRoot = element NoNS:StructTreeRoot {( Document|DocumentFragment|Part|Art|Div|Sect|TOC|Aside|BlockQuote|NonStruct|Private|P|Note|Code|Hn|H|Title|Link|Annot|Form|FENote|Index|L|Table|Figure|Formula|Artifact)*}
 
 AssociatedFile = element NoNS:AssociatedFile {
@@ -63,6 +64,10 @@ formula-requirements = (
 )
 
 ## share with pdf1.7 version from here to end
+
+XMP = element NoNS:XMP {anyelem*}
+
+anyelem = element * {(attribute * {text} | text | anyelem) *}
 
 textorHTML &= (Link|Reference|Strong|Code|Em|Lbl|Span|mathse|Quote|RB|Annot|Figure|Form)*
 
@@ -601,4 +606,5 @@ Quote = element pdf1:Quote {
 pdf2-attributes,
 (text|NonStruct|Private|Note|Code|Sub|Lbl|Em|Strong|Span|Quote|Link|Reference|Annot|Form|Ruby|Warichu|FENote|BibEntry|Figure|Formula|Artifact)*
   }
+
 

--- a/RelaxNG/document-pdf-ua1.rng
+++ b/RelaxNG/document-pdf-ua1.rng
@@ -51,6 +51,9 @@
     <element>
       <name ns="">PDF</name>
       <ref name="StructTreeRoot"/>
+      <optional>
+        <ref name="XMP"/>
+      </optional>
     </element>
   </define>
   <define name="StructTreeRoot">
@@ -119,8 +122,30 @@
       <attribute name="alt"/>
     </choice>
   </define>
-  <define name="textorHTML" combine="interleave">
+  <define name="XMP">
     <a:documentation>share with pdf1.7 version from here to end</a:documentation>
+    <element>
+      <name ns="">XMP</name>
+      <zeroOrMore>
+        <ref name="anyelem"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="anyelem">
+    <element>
+      <anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyelem"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="textorHTML" combine="interleave">
     <zeroOrMore>
       <choice>
         <ref name="Link"/>

--- a/RelaxNG/document-pdf-ua1.rng
+++ b/RelaxNG/document-pdf-ua1.rng
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- These Namespaces to be confirmed. "data:,Layout" would be another possibility -->
+<!-- XMP -->
 <!-- XHTML Namespace, not currently used -->
-<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:Table="http://iso.org/pdf/ssn/Table" xmlns:Layout="http://iso.org/pdf/ssn/Layout" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:List="http://iso.org/pdf/ssn/List" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:PrintField="http://iso.org/pdf/ssn/PrintField" xmlns:Artifact="http://iso.org/pdf/ssn/Artifact" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:Table="http://iso.org/pdf/ssn/Table" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:Artifact="http://iso.org/pdf/ssn/Artifact" xmlns:Layout="http://iso.org/pdf/ssn/Layout" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/" xmlns:List="http://iso.org/pdf/ssn/List" xmlns:PrintField="http://iso.org/pdf/ssn/PrintField" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <!-- slightly modified MathML-Core schema. -->
   <include href="latex-mathml.rng">
     <start combine="choice">
@@ -122,29 +123,87 @@
       <attribute name="alt"/>
     </choice>
   </define>
-  <define name="XMP">
-    <a:documentation>share with pdf1.7 version from here to end</a:documentation>
-    <element>
-      <name ns="">XMP</name>
-      <zeroOrMore>
-        <ref name="anyelem"/>
-      </zeroOrMore>
+  <define name="pdfuaid_part">
+    <a:documentation>PDF/UA-1</a:documentation>
+    <element name="pdfuaid:part">
+      <value>1</value>
     </element>
   </define>
+  <!-- XMP data -->
   <define name="anyelem">
+    <a:documentation>share with pdf1.7 version from here to end</a:documentation>
     <element>
       <anyName/>
       <zeroOrMore>
         <choice>
-          <attribute>
-            <anyName/>
-          </attribute>
+          <zeroOrMore>
+            <attribute>
+              <anyName/>
+            </attribute>
+          </zeroOrMore>
           <text/>
           <ref name="anyelem"/>
         </choice>
       </zeroOrMore>
     </element>
   </define>
+  <define name="XMP">
+    <element>
+      <name ns="">XMP</name>
+      <interleave>
+        <ref name="x_xmpmeta"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="x_xmpmeta">
+    <element name="x:xmpmeta">
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <interleave>
+        <ref name="rdf_RDF"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="rdf_RDF">
+    <element name="rdf:RDF">
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <interleave>
+        <ref name="rdf_Description"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="rdf_Description">
+    <element name="rdf:Description">
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <interleave>
+        <ref name="pdfuaid_part"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <!-- end of XMP -->
   <define name="textorHTML" combine="interleave">
     <zeroOrMore>
       <choice>

--- a/RelaxNG/document-pdf-ua2.rnc
+++ b/RelaxNG/document-pdf-ua2.rnc
@@ -11,6 +11,12 @@ namespace Table = "http://iso.org/pdf/ssn/Table"
 namespace List = "http://iso.org/pdf/ssn/List"
 namespace Artifact = "http://iso.org/pdf/ssn/Artifact"
 
+# XMP
+namespace x = "adobe:ns:meta/"
+namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+namespace dc = "http://purl.org/dc/elements/1.1/"
+namespace pdfuaid = "http://www.aiim.org/pdfua/ns/id/"
+
 # XHTML Namespace, not currently used
 namespace h = "http://www.w3.org/1999/xhtml"
 
@@ -63,11 +69,23 @@ formula-requirements = (
   AssociatedFilemath
 )
 
+## PDF/UA-2
+pdfuaid_part = element pdfuaid:part {"2"}
+
 ## share with pdf1.7 version from here to end
 
-XMP = element NoNS:XMP {anyelem*}
+# XMP data
+anyelem = element * {(attribute * {text}* | text | anyelem) *}
 
-anyelem = element * {(attribute * {text} | text | anyelem) *}
+XMP = element NoNS:XMP {x_xmpmeta & anyelem*}
+
+x_xmpmeta = element x:xmpmeta {attribute * {text}*,(rdf_RDF &  anyelem*)}
+
+rdf_RDF= element rdf:RDF {attribute * {text}*, (rdf_Description & anyelem*)}
+
+rdf_Description= element rdf:Description {attribute * {text}*, (pdfuaid_part & anyelem*)}
+
+# end of XMP
 
 textorHTML &= (Link|Reference|Strong|Code|Em|Lbl|Span|mathse|Quote|RB|Annot|Figure|Form)*
 

--- a/RelaxNG/document-pdf-ua2.rnc
+++ b/RelaxNG/document-pdf-ua2.rnc
@@ -38,7 +38,8 @@ pdf1rolemap-Note = notAllowed?
 # UA-2 Single Document element root.
 start = PDF
 
-PDF = element NoNS:PDF {StructTreeRoot}
+PDF = element NoNS:PDF {StructTreeRoot,XMP?}
+
 StructTreeRoot = element NoNS:StructTreeRoot {Document|DocumentFragment}
 
 AssociatedFile = element NoNS:AssociatedFile {
@@ -63,6 +64,10 @@ formula-requirements = (
 )
 
 ## share with pdf1.7 version from here to end
+
+XMP = element NoNS:XMP {anyelem*}
+
+anyelem = element * {(attribute * {text} | text | anyelem) *}
 
 textorHTML &= (Link|Reference|Strong|Code|Em|Lbl|Span|mathse|Quote|RB|Annot|Figure|Form)*
 

--- a/RelaxNG/document-pdf-ua2.rng
+++ b/RelaxNG/document-pdf-ua2.rng
@@ -52,6 +52,9 @@
     <element>
       <name ns="">PDF</name>
       <ref name="StructTreeRoot"/>
+      <optional>
+        <ref name="XMP"/>
+      </optional>
     </element>
   </define>
   <define name="StructTreeRoot">
@@ -100,8 +103,30 @@
       <ref name="AssociatedFilemath"/>
     </choice>
   </define>
-  <define name="textorHTML" combine="interleave">
+  <define name="XMP">
     <a:documentation>share with pdf1.7 version from here to end</a:documentation>
+    <element>
+      <name ns="">XMP</name>
+      <zeroOrMore>
+        <ref name="anyelem"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="anyelem">
+    <element>
+      <anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyelem"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="textorHTML" combine="interleave">
     <zeroOrMore>
       <choice>
         <ref name="Link"/>

--- a/RelaxNG/document-pdf-ua2.rng
+++ b/RelaxNG/document-pdf-ua2.rng
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- These Namespaces to be confirmed. "data:,Layout" would be another possibility -->
+<!-- XMP -->
 <!-- XHTML Namespace, not currently used -->
-<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:Table="http://iso.org/pdf/ssn/Table" xmlns:pdf2="http://iso.org/pdf2/ssn" xmlns:Layout="http://iso.org/pdf/ssn/Layout" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:List="http://iso.org/pdf/ssn/List" xmlns:pdf1="http://iso.org/pdf/ssn" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:PrintField="http://iso.org/pdf/ssn/PrintField" xmlns:Artifact="http://iso.org/pdf/ssn/Artifact" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:Table="http://iso.org/pdf/ssn/Table" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:pdf1="http://iso.org/pdf/ssn" xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:Artifact="http://iso.org/pdf/ssn/Artifact" xmlns:pdf2="http://iso.org/pdf2/ssn" xmlns:Layout="http://iso.org/pdf/ssn/Layout" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/" xmlns:List="http://iso.org/pdf/ssn/List" xmlns:PrintField="http://iso.org/pdf/ssn/PrintField" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <!-- slightly modified MathML-Core schema. -->
   <include href="latex-mathml.rng">
     <start combine="choice">
@@ -103,29 +104,87 @@
       <ref name="AssociatedFilemath"/>
     </choice>
   </define>
-  <define name="XMP">
-    <a:documentation>share with pdf1.7 version from here to end</a:documentation>
-    <element>
-      <name ns="">XMP</name>
-      <zeroOrMore>
-        <ref name="anyelem"/>
-      </zeroOrMore>
+  <define name="pdfuaid_part">
+    <a:documentation>PDF/UA-2</a:documentation>
+    <element name="pdfuaid:part">
+      <value>2</value>
     </element>
   </define>
+  <!-- XMP data -->
   <define name="anyelem">
+    <a:documentation>share with pdf1.7 version from here to end</a:documentation>
     <element>
       <anyName/>
       <zeroOrMore>
         <choice>
-          <attribute>
-            <anyName/>
-          </attribute>
+          <zeroOrMore>
+            <attribute>
+              <anyName/>
+            </attribute>
+          </zeroOrMore>
           <text/>
           <ref name="anyelem"/>
         </choice>
       </zeroOrMore>
     </element>
   </define>
+  <define name="XMP">
+    <element>
+      <name ns="">XMP</name>
+      <interleave>
+        <ref name="x_xmpmeta"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="x_xmpmeta">
+    <element name="x:xmpmeta">
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <interleave>
+        <ref name="rdf_RDF"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="rdf_RDF">
+    <element name="rdf:RDF">
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <interleave>
+        <ref name="rdf_Description"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="rdf_Description">
+    <element name="rdf:Description">
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <interleave>
+        <ref name="pdfuaid_part"/>
+        <zeroOrMore>
+          <ref name="anyelem"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <!-- end of XMP -->
   <define name="textorHTML" combine="interleave">
     <zeroOrMore>
       <choice>

--- a/RelaxNG/latex-custom.rnc
+++ b/RelaxNG/latex-custom.rnc
@@ -2,6 +2,7 @@ namespace latexSEplay = "https://www.latex-project.org/ns/local/plays"
 namespace latexSEamse = "https://www.latex-project.org/ns/local/asmeconf"
 namespace luatexko = "https://www.latex-project.org/ns/local/luatexko"
 namespace latexSEamsej = "https://www.latex-project.org/ns/local/asmejour"
+namespace mitthesis = "https://www.latex-project.org/ns/local/mitthesis"
 
 include "latex-document.rnc"
 
@@ -40,6 +41,14 @@ Div |= element latexSEamsej:Author_Block {
   text-unit*
   }
 
+Div |= element latexSEamse:Paper_number {
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+
 
 # luatexko
 
@@ -60,3 +69,76 @@ Div|= element luatexko:Horizontal {
   attribute rolemaps-to {"Div"},
   (text-unit|P)*
 }
+
+## mithesis
+Div |= element mitthesis:Author{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Div |= element mitthesis:Degree{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Div |= element mitthesis:Copyright{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+
+Div |= element mitthesis:Title_sig_block{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Div |= element mitthesis:Nomenclature_list{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Div |= element mitthesis:Abstract_title{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Div |= element mitthesis:Abstract_text{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Div |= element mitthesis:Abstract_supervisor{
+  showtags-attributes,
+  attribute rolemaps-to {"Div"},
+  attribute id {text}?,
+  attribute title {text}?,
+  text-unit*
+  }
+Sect |= element mitthesis:Abstract_page{
+  showtags-attributes,
+  attribute rolemaps-to {"Sect"},
+  attribute id {text}?,
+  attribute title {text}?,
+  (Div|text-unit)*
+  }
+Span |= element mitthesis:Nomenclature_entry_heading{
+  showtags-attributes,
+  attribute rolemaps-to {"Span"},
+  attribute id {text}?,
+  attribute title {text}?,
+  (Em|Span)*
+  }

--- a/RelaxNG/latex-custom.rng
+++ b/RelaxNG/latex-custom.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns:latexSEamse="https://www.latex-project.org/ns/local/asmeconf" xmlns:latexSEamsej="https://www.latex-project.org/ns/local/asmejour" xmlns:luatexko="https://www.latex-project.org/ns/local/luatexko" xmlns:latexSEplay="https://www.latex-project.org/ns/local/plays" xmlns="http://relaxng.org/ns/structure/1.0">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:latexSEamse="https://www.latex-project.org/ns/local/asmeconf" xmlns:latexSEamsej="https://www.latex-project.org/ns/local/asmejour" xmlns:luatexko="https://www.latex-project.org/ns/local/luatexko" xmlns:mitthesis="https://www.latex-project.org/ns/local/mitthesis" xmlns:latexSEplay="https://www.latex-project.org/ns/local/plays" xmlns="http://relaxng.org/ns/structure/1.0">
   <include href="latex-document.rng"/>
   <!-- LaTeX play -->
   <define name="Span" combine="choice">
@@ -80,6 +80,23 @@
       </zeroOrMore>
     </element>
   </define>
+  <define name="Div" combine="choice">
+    <element name="latexSEamse:Paper_number">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
   <!-- luatexko -->
   <define name="Span" combine="choice">
     <element name="luatexko:StrikeOut">
@@ -119,6 +136,183 @@
         <choice>
           <ref name="text-unit"/>
           <ref name="P"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <a:documentation>mithesis</a:documentation>
+    <element name="mitthesis:Author">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Degree">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Copyright">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Title_sig_block">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Nomenclature_list">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Abstract_title">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Abstract_text">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Div" combine="choice">
+    <element name="mitthesis:Abstract_supervisor">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Div</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="text-unit"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Sect" combine="choice">
+    <element name="mitthesis:Abstract_page">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Sect</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="Div"/>
+          <ref name="text-unit"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Span" combine="choice">
+    <element name="mitthesis:Nomenclature_entry_heading">
+      <ref name="showtags-attributes"/>
+      <attribute name="rolemaps-to">
+        <value>Span</value>
+      </attribute>
+      <optional>
+        <attribute name="id"/>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="Em"/>
+          <ref name="Span"/>
         </choice>
       </zeroOrMore>
     </element>

--- a/show-pdf-tags/show-pdf-tags.1
+++ b/show-pdf-tags/show-pdf-tags.1
@@ -41,6 +41,8 @@ Valid <options> are:
 .TP
    \fB--map\fR            Follow role mapping (xml printer)
 .TP
+   \fB--xmp\fR            Include XMP XML (xml printer)
+.TP
    \fB--w3c-\fR           Add - to w3c namespaces to force browser display
 .PP
 .FI
@@ -53,4 +55,4 @@ Repository : https://github.com/latex3/pdf_structure
 Bug tracker: https://github.com/latex3/pdf_structure/issues
 
 .SH AUTHORS
-Copyright (C) 2024-2025 The LaTeX Project
+Copyright (C) 2024-2026 The LaTeX Project

--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -12,6 +12,7 @@ end
 local out_format = "tree"
 local follow_rolemap = false
 local hide_w3c = false
+local show_xmp = false
 
 local pdfe = pdfe or require'pdfe'
 local process_stream = require'show-pdf-tags_process_stream'
@@ -317,6 +318,7 @@ local function open(filename)
   local catalog = pdfe.getcatalog(document)
   local markinfo = catalog and catalog.MarkInfo
   local tagged = markinfo and markinfo.Marked
+  local xmp = catalog and catalog.Metadata
 
   if not tagged then
    io.stderr:write("Document catalog has no markinfo.Marked entry. It might not be tagged.\n")
@@ -332,6 +334,8 @@ local function open(filename)
   ctx.id_map = id_map
   ctx.ref_entries = {}
 
+  ctx.xmp = xmp
+  
   local structroot = catalog.StructTreeRoot
   if not structroot then
     return {}, ctx
@@ -697,7 +701,11 @@ local function print_tree_xml(tree, ctx)
   end
   print ("<PDF>\n <StructTreeRoot>")
   recurse(tree, '  ', '', '', ' ')
-  print (" </StructTreeRoot>\n</PDF>")
+  print (" </StructTreeRoot>\n")
+  if show_xmp then
+    print(" <XMP>\n" ..pdfe.readwholestream(ctx.xmp,true):gsub("\n[ \n]*\n","\n") .. "\n </XMP>\n")
+  end
+  print ("</PDF>")
   return
 end
 
@@ -712,6 +720,7 @@ Options
   --xml            show as XML
   --table          show Lua table structure
   --map            Follow role mapping (xml printer)
+  --xmp            include XMP XML (xml printer)
   --w3c-           Add - to w3c namespaces to force browser tree display
 
 ]]
@@ -728,6 +737,8 @@ while argi <= #arg and arg[argi]:match("^%-") do
     follow_rolemap=true
   elseif arg[argi] == "--w3c-" then
     hide_w3c=true
+  elseif arg[argi] == "--xmp" then
+    show_xmp=true
   elseif arg[argi] == "--help" or arg[argi] == "-h" then
     io.stderr:write(string.format(helpstr, arg[0]))
     return


### PR DESCRIPTION
This adds an --xmp option that can be used in addition to --xml to get the XMP metadata (in an `<XMP>` element.

Currently the Relax NG schema doesn't know about this, that will be addressed separately (it will need a lax validation that allows any unknown elements but validates any that are known to the schema)

