### PR TITLE
avoid blank line before </PDF>

### DIFF
--- a/show-pdf-tags/README.md
+++ b/show-pdf-tags/README.md
@@ -1,6 +1,6 @@
 # Print structure element hierarchy for Tagged PDF
 
-show-pdf-tags version 1.4
+show-pdf-tags version 1.5
 
 Print a plain text or XML tree representing the structure of tagged PDF files.
 

--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env texlua
 
-local show_pdf_tags_version = "1.4"
+local show_pdf_tags_version = "1.5"
 
 kpse.set_program_name'lualatex'
 
@@ -701,9 +701,9 @@ local function print_tree_xml(tree, ctx)
   end
   print ("<PDF>\n <StructTreeRoot>")
   recurse(tree, '  ', '', '', ' ')
-  print (" </StructTreeRoot>\n")
+  print (" </StructTreeRoot>")
   if show_xmp then
-    print(" <XMP>\n" ..pdfe.readwholestream(ctx.xmp,true):gsub("\n[ \n]*\n","\n") .. "\n </XMP>\n")
+    print(" <XMP>\n" ..pdfe.readwholestream(ctx.xmp,true):gsub("\n[ \n]*\n","\n") .. "\n </XMP>")
   end
   print ("</PDF>")
   return


### PR DESCRIPTION
Adding the XMP output option in v1.4 accidentally added a blank line if XMP is not used, which changed every output in the tagging test suite. This restores the status quo.

Although this is a rather trivial update I think we should push to ctan/texlive (rather than change the tagging suite to use the github version)