### PR TITLE
local function to quote SE name for xml

### DIFF
--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -416,12 +416,19 @@ local function format_subtype(subtype)
   end
 end
 
+local function format_xml_name(s)
+-- %p would include _
+   return s:gsub("([:+(),@%s])",
+                 function (c) return string.format("_x%02X_",c:byte()) end
+		 )
+ end
+
 local function format_subtype_xml(subtype)
   if subtype.namespace then
     return string.format('<%s xmlns="%s"', subtype.subtype,
                   (hide_w3c and subtype.namespace:gsub('http://www.w3.org', 'http://-www.w3.org')) or subtype.namespace)
   else
-    return "<" .. subtype.subtype:gsub(":","_x3A_")
+    return "<" .. format_xml_name(subtype.subtype)
   end
 end
 
@@ -683,7 +690,7 @@ local function print_tree_xml(tree, ctx)
         if follow_rolemap and mapped then
 	  print(indent .. "</" .. mapped.subtype ..">")
 	else
-	  print(indent .. "</" .. subtype.subtype:gsub(":","_x3A_") ..">")
+	  print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
 	end
         elseif #lines > 0 then
           for i=1, #lines-1 do
@@ -693,7 +700,7 @@ local function print_tree_xml(tree, ctx)
           if follow_rolemap and mapped then
             print(indent .. "</" .. mapped.subtype ..">")
 	  else
-            print(indent .. "</" .. subtype.subtype:gsub(":","_x3A_") ..">")
+            print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
 	  end
         end
       end

--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -418,14 +418,14 @@ end
 
 local function format_xml_name(s)
 -- %p would include _
-   return s:gsub("([:+(),@%s])",
+   return s:gsub("([:+(),@%s#])",
                  function (c) return string.format("_x%02X_",c:byte()) end
 		 )
  end
 
 local function format_subtype_xml(subtype)
   if subtype.namespace then
-    return string.format('<%s xmlns="%s"', subtype.subtype,
+    return string.format('<%s xmlns="%s"', format_xml_name(subtype.subtype),
                   (hide_w3c and subtype.namespace:gsub('http://www.w3.org', 'http://-www.w3.org')) or subtype.namespace)
   else
     return "<" .. format_xml_name(subtype.subtype)
@@ -688,7 +688,7 @@ local function print_tree_xml(tree, ctx)
           end
           recurse(obj.kids, indent .. ' ')
         if follow_rolemap and mapped then
-	  print(indent .. "</" .. mapped.subtype ..">")
+	  print(indent .. "</" .. format_xml_name(mapped.subtype) ..">")
 	else
 	  print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
 	end
@@ -698,7 +698,7 @@ local function print_tree_xml(tree, ctx)
           end
           print(indent .. '  ' .. lines[#lines]:gsub('\n', '\n' .. indent .. '   '))
           if follow_rolemap and mapped then
-            print(indent .. "</" .. mapped.subtype ..">")
+            print(indent .. "</" .. format_xml_name(mapped.subtype) ..">")
 	  else
             print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
 	  end

--- a/show-pdf-tags/testfiles/quote-names-01-map.xml
+++ b/show-pdf-tags/testfiles/quote-names-01-map.xml
@@ -1,0 +1,52 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Part xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+      xmlns:orig-ns="https://www.latex-project.org/ns/dflt"
+      rolemapped-from="orig-ns:text-unit"
+     >
+    <P xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       xmlns:orig-ns="https://www.latex-project.org/ns/dflt"
+       rolemapped-from="orig-ns:text"
+      >
+     <?MarkedContent page="1" ?>text 
+     <i xmlns="http://www.w3.org/1999/xhtml"
+        id="ID.008"
+        xmlns:orig-ns="https://www.latex-project.org/ns/local/testing"
+        rolemapped-from="orig-ns:this#20#39#20#28name#29"
+       >
+      <?MarkedContent page="1" ?>hello1
+     </i>
+    </P>
+   </Part>
+   <Part xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      xmlns:orig-ns="https://www.latex-project.org/ns/dflt"
+      rolemapped-from="orig-ns:text-unit"
+     >
+    <P xmlns="http://iso.org/pdf2/ssn"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       xmlns:orig-ns="https://www.latex-project.org/ns/dflt"
+       rolemapped-from="orig-ns:text"
+      >
+     <?MarkedContent page="1" ?>text 
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+        xmlns:orig-ns="http://www.w3.org/1999/xhtml"
+        rolemapped-from="orig-ns:i"
+       >
+      <?MarkedContent page="1" ?>hello2
+     </Span>
+    </P>
+   </Part>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/show-pdf-tags/testfiles/quote-names-01.tex
+++ b/show-pdf-tags/testfiles/quote-names-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata{tagging=on,uncompress}
+\documentclass{article}
+
+\ExplSyntaxOn
+\__tag_role_NS_new:nnn {html}   {http://www.w3.org/1999/xhtml}{}
+\tagpdfsetup{
+  role/new-tag={tag=i, role=Span, tag-namespace=html},
+ }
+
+\ExplSyntaxOff
+
+\catcode`\#=12
+\tagpdfsetup{
+  role/user-NS=testing,
+  role/new-tag = {tag={this#20#39#20#28name#29},role=i}}
+\catcode`\#=6
+
+\begin{document}
+
+\catcode`\#=12
+text \tagstructbegin{tag={this#20#39#20#28name#29}}\tagmcbegin{}hello1\tagmcend{}\tagstructend{}
+\catcode`\#=6
+
+text \tagstructbegin{tag=i}\tagmcbegin{}hello2\tagmcend{}\tagstructend{}
+
+\end{document}

--- a/show-pdf-tags/testfiles/quote-names-01.xml
+++ b/show-pdf-tags/testfiles/quote-names-01.xml
@@ -1,0 +1,46 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text 
+     <this_x23_20_x23_39_x23_20_x23_28name_x23_29 xmlns="https://www.latex-project.org/ns/local/testing"
+        id="ID.008"
+        rolemaps-to="i"
+       >
+      <?MarkedContent page="1" ?>hello1
+     </this_x23_20_x23_39_x23_20_x23_28name_x23_29>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text 
+     <i xmlns="http://www.w3.org/1999/xhtml"
+        id="ID.011"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>hello2
+     </i>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>


### PR DESCRIPTION
bad xml element names was always a possibility but I hoped it wouldn't show up but PDFA reports use SE with spaces in their names  eg `A4 V:Subtitle_`  which is now quoted as `4_x20_V_x3A_Subtitle_`

as a PR mostly in case anyone wants to review my Lua style:-)