### PR TITLE
show AFRelationship and mime type

### DIFF
--- a/RelaxNG/document-pdf-ua1.rnc
+++ b/RelaxNG/document-pdf-ua1.rnc
@@ -65,6 +65,8 @@ attribute media-type {text}?,
 }
 AssociatedFiletext = element NoNS:AssociatedFile {
 attribute name {text},
+attribute relationship {text}?,
+attribute media-type {text}?,
 (text)
 }
 

--- a/RelaxNG/document-pdf-ua1.rnc
+++ b/RelaxNG/document-pdf-ua1.rnc
@@ -52,11 +52,15 @@ StructTreeRoot = element NoNS:StructTreeRoot {( Document|DocumentFragment|Part|A
 
 AssociatedFile = element NoNS:AssociatedFile {
 attribute name {text},
+attribute relationship {text}?,
+attribute media-type {text}?,
 (text|math)
 }
 
 AssociatedFilemath = element NoNS:AssociatedFile {
 attribute name {text},
+attribute relationship {text}?,
+attribute media-type {text}?,
 (math)
 }
 AssociatedFiletext = element NoNS:AssociatedFile {

--- a/RelaxNG/document-pdf-ua1.rng
+++ b/RelaxNG/document-pdf-ua1.rng
@@ -126,6 +126,12 @@
     <element>
       <name ns="">AssociatedFile</name>
       <attribute name="name"/>
+      <optional>
+        <attribute name="relationship"/>
+      </optional>
+      <optional>
+        <attribute name="media-type"/>
+      </optional>
       <text/>
     </element>
   </define>

--- a/RelaxNG/document-pdf-ua1.rng
+++ b/RelaxNG/document-pdf-ua1.rng
@@ -97,6 +97,12 @@
     <element>
       <name ns="">AssociatedFile</name>
       <attribute name="name"/>
+      <optional>
+        <attribute name="relationship"/>
+      </optional>
+      <optional>
+        <attribute name="media-type"/>
+      </optional>
       <choice>
         <text/>
         <ref name="math"/>
@@ -107,6 +113,12 @@
     <element>
       <name ns="">AssociatedFile</name>
       <attribute name="name"/>
+      <optional>
+        <attribute name="relationship"/>
+      </optional>
+      <optional>
+        <attribute name="media-type"/>
+      </optional>
       <ref name="math"/>
     </element>
   </define>

--- a/RelaxNG/document-pdf-ua2.rnc
+++ b/RelaxNG/document-pdf-ua2.rnc
@@ -50,15 +50,21 @@ StructTreeRoot = element NoNS:StructTreeRoot {Document|DocumentFragment}
 
 AssociatedFile = element NoNS:AssociatedFile {
 attribute name {text},
+attribute relationship {text}?,
+attribute media-type {text}?,
 (text|math)
 }
 
 AssociatedFilemath = element NoNS:AssociatedFile {
 attribute name {text},
+attribute relationship {"Supplement"},
+attribute media-type {"application/mathml+xml"},
 (math)
 }
 AssociatedFiletext = element NoNS:AssociatedFile {
 attribute name {text},
+attribute relationship {text}?,
+attribute media-type {text}?,
 (text)
 }
 

--- a/RelaxNG/document-pdf-ua2.rng
+++ b/RelaxNG/document-pdf-ua2.rng
@@ -71,6 +71,12 @@
     <element>
       <name ns="">AssociatedFile</name>
       <attribute name="name"/>
+      <optional>
+        <attribute name="relationship"/>
+      </optional>
+      <optional>
+        <attribute name="media-type"/>
+      </optional>
       <choice>
         <text/>
         <ref name="math"/>
@@ -81,6 +87,12 @@
     <element>
       <name ns="">AssociatedFile</name>
       <attribute name="name"/>
+      <attribute name="relationship">
+        <value>Supplement</value>
+      </attribute>
+      <attribute name="media-type">
+        <value>application/mathml+xml</value>
+      </attribute>
       <ref name="math"/>
     </element>
   </define>
@@ -88,6 +100,12 @@
     <element>
       <name ns="">AssociatedFile</name>
       <attribute name="name"/>
+      <optional>
+        <attribute name="relationship"/>
+      </optional>
+      <optional>
+        <attribute name="media-type"/>
+      </optional>
       <text/>
     </element>
   </define>

--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -420,7 +420,7 @@ local function format_xml_name(s)
 -- %p would include _
    return s:gsub("([:+(),@%s#])",
                  function (c) return string.format("_x%02X_",c:byte()) end
-		 )
+                 )
  end
 
 local function format_subtype_xml(subtype)
@@ -570,14 +570,14 @@ local function print_tree_xml(tree, ctx)
         print(string.format('%s<?ReferencedObject%s%s ?>', indent, t, page))
       else
         local subtype = obj.subtype
-	local mapped = subtype.mapped
+        local mapped = subtype.mapped
 --        mapped = mapped and mapped.subtype or ''
 --        mapped = mapped and ' / ' .. format_subtype(mapped) or ''
         if follow_rolemap and mapped then
           print(string.format('%s%s', indent, format_subtype_xml(mapped)))
-	else
+        else
           print(string.format('%s%s', indent, format_subtype_xml(subtype)))
-	end
+        end
         local lines = {}
         if obj.id then
           lines[#lines + 1] = ' id="' .. obj.id:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]') .. '"'
@@ -604,33 +604,33 @@ local function print_tree_xml(tree, ctx)
           lines[#lines + 1] = ' phonetic-alphabet="' .. obj.phonetic_alphabet:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]'):gsub('[\1-\8\11\12\14-\31]','[CTRL]') .. '"'
         end
         if obj.associated_files then
-	  local f = {}
-	  local warnings = {}
-	  for i, file in ipairs(obj.associated_files) do
+          local f = {}
+          local warnings = {}
+          for i, file in ipairs(obj.associated_files) do
             if file.EF.F then
-	      f[#f+1] = get_string(file, "UF", warnings) 
+              f[#f+1] = get_string(file, "UF", warnings) 
             end
-	  end
-	  for _, warning in ipairs(warnings) do
+          end
+          for _, warning in ipairs(warnings) do
             io.stderr:write('Warning while processing associated files: ' .. warning .. '\n')
-	  end
+          end
           lines[#lines + 1] = ' af="' .. table.concat(f, ' ') .. '"'
         end
         if obj.attributes then
-	  for k,v in ordered_pairs(obj.attributes) do
+          for k,v in ordered_pairs(obj.attributes) do
             local attrns=""
-	    if k~=subtype.namespace then
-	      attrns = k:gsub('.*/','')
-	    end
+            if k~=subtype.namespace then
+              attrns = k:gsub('.*/','')
+            end
             if type(v) == "table" then
-	      if attrns ~= "" then
+              if attrns ~= "" then
                 lines[#lines +1] = ' xmlns:' .. attrns .. '="' .. k .. '"'
-		attrns = attrns ..':'
+                attrns = attrns ..':'
               end
               for kk,vv in ordered_pairs(v) do
-	        if type(vv) == "table" then
-	          vv = require'show-pdf-tags-inspect'(vv):gsub('\n[ ]*',' ')
-	        end
+                if type(vv) == "table" then
+                  vv = require'show-pdf-tags-inspect'(vv):gsub('\n[ ]*',' ')
+                end
                 lines[#lines+1] = ' ' ..attrns .. format_xml_name(kk) .. '="' .. tostring(vv):gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]') .. '"'
               end
             else
@@ -638,44 +638,44 @@ local function print_tree_xml(tree, ctx)
             end
           end
         end
-	if mapped and mapped.subtype then
+        if mapped and mapped.subtype then
           if follow_rolemap then
-	    if subtype.namespace then
+            if subtype.namespace then
               lines[#lines+1] = ' xmlns:orig-ns="' .. subtype.namespace .. '"'
               lines[#lines+1] = ' rolemapped-from="orig-ns:' .. subtype.subtype .. '"'
-	    else
+            else
               lines[#lines+1] = ' rolemapped-from="' .. subtype.subtype .. '"'
-	    end
-	  else
+            end
+          else
             lines[#lines+1] = ' rolemaps-to="' .. mapped.subtype .. '"'
-	  end
-	end
+          end
+        end
         -- attributes = convert_attributes(elem.A),
         -- attribute_classes = convert_attribute_classes(elem.C),
         if referenced[obj] then
           lines[#lines + 1] = ' referenced-as="' .. referenced[obj] .. '"'
         end
-	lines[#lines+1] = ">"
+        lines[#lines+1] = ">"
 --
         if obj.associated_files then
-	  local f = {}
+          local f = {}
           local af_output = ''
-	  local warnings = {}
-	  for i, file in ipairs(obj.associated_files) do
+          local warnings = {}
+          for i, file in ipairs(obj.associated_files) do
             if file.EF.F then
-	      af_output = pdfe.readwholestream(file.EF.F, true)
+              af_output = pdfe.readwholestream(file.EF.F, true)
               lines[#lines + 1] = '<AssociatedFile name="' .. get_string(file, "UF", warnings) .. '"' ..
-	                           (file.AFRelationship and (' relationship="' .. file.AFRelationship ..'"') or '') ..
-	                           (file.EF.F.Subtype and (' media-type="' .. file.EF.F.Subtype ..'"') or '') ..
-				     ' xmlns="">'
-	      if file.EF.F.Subtype == 'application/mathml+xml' then
+                                   (file.AFRelationship and (' relationship="' .. file.AFRelationship ..'"') or '') ..
+                                   (file.EF.F.Subtype and (' media-type="' .. file.EF.F.Subtype ..'"') or '') ..
+                                   ' xmlns="">'
+              if file.EF.F.Subtype == 'application/mathml+xml' then
                 lines[#lines + 1] = af_output
-	      else
+              else
                 lines[#lines + 1] = af_output:gsub('&','&amp;'):gsub('<','&lt;'):gsub('"','&quot;'):gsub('\0','[NULL]'):gsub('[\1-\8\11\12\14-\31]','[CTRL]')
-              end	  
+              end         
               lines[#lines + 1] = '</AssociatedFile>'
             end
-	  end
+          end
         end
 --
         if obj.ref then
@@ -691,10 +691,10 @@ local function print_tree_xml(tree, ctx)
           end
           recurse(obj.kids, indent .. ' ')
         if follow_rolemap and mapped then
-	  print(indent .. "</" .. format_xml_name(mapped.subtype) ..">")
-	else
-	  print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
-	end
+          print(indent .. "</" .. format_xml_name(mapped.subtype) ..">")
+        else
+          print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
+        end
         elseif #lines > 0 then
           for i=1, #lines-1 do
             print(indent .. '  ' .. lines[i]:gsub('\n', '\n' .. indent .. '  '))
@@ -702,9 +702,9 @@ local function print_tree_xml(tree, ctx)
           print(indent .. '  ' .. lines[#lines]:gsub('\n', '\n' .. indent .. '   '))
           if follow_rolemap and mapped then
             print(indent .. "</" .. format_xml_name(mapped.subtype) ..">")
-	  else
+          else
             print(indent .. "</" .. format_xml_name(subtype.subtype) ..">")
-	  end
+          end
         end
       end
     end

--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -663,7 +663,6 @@ local function print_tree_xml(tree, ctx)
 	  local warnings = {}
 	  for i, file in ipairs(obj.associated_files) do
             if file.EF.F then
-	      local filet=pdfe.dictionarytotable(file)
 	      af_output = pdfe.readwholestream(file.EF.F, true)
               lines[#lines + 1] = '<AssociatedFile name="' .. get_string(file, "UF", warnings) .. '"' ..
 	                           (file.AFRelationship and (' relationship="' .. file.AFRelationship ..'"') or '') ..

--- a/show-pdf-tags/show-pdf-tags.lua
+++ b/show-pdf-tags/show-pdf-tags.lua
@@ -663,8 +663,12 @@ local function print_tree_xml(tree, ctx)
 	  local warnings = {}
 	  for i, file in ipairs(obj.associated_files) do
             if file.EF.F then
+	      local filet=pdfe.dictionarytotable(file)
 	      af_output = pdfe.readwholestream(file.EF.F, true)
-              lines[#lines + 1] = '<AssociatedFile name="' .. get_string(file, "UF", warnings) .. '" xmlns="">'
+              lines[#lines + 1] = '<AssociatedFile name="' .. get_string(file, "UF", warnings) .. '"' ..
+	                           (file.AFRelationship and (' relationship="' .. file.AFRelationship ..'"') or '') ..
+	                           (file.EF.F.Subtype and (' media-type="' .. file.EF.F.Subtype ..'"') or '') ..
+				     ' xmlns="">'
 	      if file.EF.F.Subtype == 'application/mathml+xml' then
                 lines[#lines + 1] = af_output
 	      else


### PR DESCRIPTION
Extends the output for Associated files producing

```
<AssociatedFile
   name="mathml-1.xml"
   relationship="Data"
   media-type="application/mathml+xml"
   xmlns=""
  >
```

Which allows these to be validated (MathML AF should be `Supplement`) but it's a breaking change, changing all test file output
for files with AF.

